### PR TITLE
Fix Hamburger Menu

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -14,6 +14,11 @@
   .page-link {
     color: gray !important;
   }
+  .site-nav {
+    background-color: black;
+    border: 1px solid black;
+  }
+    
 
   header,
   .site-footer {


### PR DESCRIPTION
When in Dark Mode, the hamburger menu that shows up in narrower
screens is in white.  This fixes the background.
